### PR TITLE
Allow Hotfixes to Deploy to Release

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - release/**
+      - hotfix/**
 jobs:
   semver:
     name: Determine SemVer

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,7 +2,6 @@ name: Test PR
 on:
   pull_request:
     branches:
-      - master
       - develop
 jobs:
   lint:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - release
+      - develop
 jobs:
   lint:
     name: Check Linter


### PR DESCRIPTION
Hot fixes should deploy to release on every push to ensure a stable environment before merging into master