### PR TITLE
Remove format from pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"prepare": "svelte-kit sync"
 	},
 	"pre-commit": [
-		"format",
 		"lint",
 		"test:unit"
 	],


### PR DESCRIPTION
Formatting in the precommit step doesn't work as intended. Instead, run the format command then commit.